### PR TITLE
Fix broken frontend

### DIFF
--- a/app/scripts/services/jwt-token-storage.ts
+++ b/app/scripts/services/jwt-token-storage.ts
@@ -31,7 +31,7 @@ module labsFrontendApp
          */
         public put( token: string )
         {
-            this.$cookies.put( 'jwt', token );
+            this.$cookies.put( 'jwt', token, {secure: true} );
         }
 
         /**

--- a/bower.json
+++ b/bower.json
@@ -2,20 +2,20 @@
   "name": "labs-frontend",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "^1.4.0",
-    "angular-animate": "^1.4.0",
-    "angular-cookies": "^1.4.0",
+    "angular": "~1.4.0",
+    "angular-animate": "~1.4.0",
+    "angular-cookies": "~1.4.0",
     "angular-jwt": "~0.0.9",
-    "angular-resource": "^1.4.0",
-    "angular-sanitize": "^1.4.0",
-    "angular-touch": "^1.4.0",
+    "angular-resource": "~1.4.0",
+    "angular-sanitize": "~1.4.0",
+    "angular-touch": "~1.4.0",
     "angular-ui-router": "~0.2.15",
     "angular-utf8-base64": "~0.0.5",
     "font-awesome": "~4.4.0",
     "jquery": "3.0.0"
   },
   "devDependencies": {
-    "angular-mocks": "^1.4.0"
+    "angular-mocks": "~1.4.0"
   },
   "appPath": "app",
   "moduleName": "labsFrontendApp",

--- a/test/mock/in-memory-cookies-service.ts
+++ b/test/mock/in-memory-cookies-service.ts
@@ -34,13 +34,18 @@ module labsFrontendApp
         putObject(key: string, value: any, options?: any): void
         {
             this[key] = value;
-            this.__options = options;
+            this.__options[key] = options;
         }
 
         remove(key: string, options?: any): void
         {
             delete this[key];
             delete this.__options[key];
+        }
+
+        getOptions(key: string): any
+        {
+            return this.__options[key];
         }
     }
 }

--- a/test/mock/in-memory-cookies-service.ts
+++ b/test/mock/in-memory-cookies-service.ts
@@ -1,0 +1,46 @@
+module labsFrontendApp
+{
+    export class InMemoryCookiesService implements ng.cookies.ICookiesService
+    {
+        private __options: Object;
+
+        constructor()
+        {
+            this.__options = {};
+        }
+
+        [index: string]: any;
+
+        get(key: string): string
+        {
+            return <string>this.getObject(key);
+        }
+
+        getObject(key: string): any
+        {
+            return this[key];
+        }
+
+        getAll(): any
+        {
+            return this;
+        }
+
+        put(key: string, value: string, options?: any): void
+        {
+            this.putObject(key, value, options);
+        }
+
+        putObject(key: string, value: any, options?: any): void
+        {
+            this[key] = value;
+            this.__options = options;
+        }
+
+        remove(key: string, options?: any): void
+        {
+            delete this[key];
+            delete this.__options[key];
+        }
+    }
+}

--- a/test/mock/services/jwt-token-storage.ts
+++ b/test/mock/services/jwt-token-storage.ts
@@ -1,0 +1,24 @@
+module labsFrontendApp
+{
+    export class InMemoryJwtTokenStorage implements JwtTokenStorage
+    {
+        private jwt: string;
+
+        /**
+         * Put a token into the storage
+         * @param token
+         */
+        public put(token: string)
+        {
+            this.jwt = token;
+        }
+
+        /**
+         * Get the token
+         */
+        public get():string
+        {
+            return this.jwt;
+        }
+    }
+}

--- a/test/spec/controllers/jwt-callback.ts
+++ b/test/spec/controllers/jwt-callback.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../app/scripts/controllers/jwt-callback.ts" />
 /// <reference path="../../../app/scripts/services/jwt-token-storage.ts" />
+/// <reference path="../../mock/services/jwt-token-storage.ts"/>
 
 'use strict';
 module labsFrontendApp
@@ -14,11 +15,11 @@ module labsFrontendApp
         var scope: IJwtCallbackScope;
 
         // Initialize the controller and a mock scope
-        beforeEach( inject( ( $cookies: ng.cookies.ICookiesService, $location: ng.ILocationService, $q: ng.IQService, $rootScope: ng.IRootScopeService ) =>
+        beforeEach( inject( ( $location: ng.ILocationService, $q: ng.IQService, $rootScope: ng.IRootScopeService ) =>
         {
             location = $location;
             scope = { currentGroup: {id: undefined, name: "", url: "", isAdmin: undefined}, groups: [] };
-            jwtTokenStorage = new CookieJwtTokenStorage( $cookies );
+            jwtTokenStorage = new InMemoryJwtTokenStorage();
             decoder = new JwtTokenDecoderStub<JwtToken>( $q, {groupId: 123, userId: 12345, isAdmin: true} );
             rootScope = $rootScope;
         } ) );

--- a/test/spec/services/jwt-token-storage.ts
+++ b/test/spec/services/jwt-token-storage.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../app/scripts/services/jwt-token-storage.ts" />
 /// <reference path="../../../typings/tsd.d.ts" />
 /// <reference path="../../../app/scripts/app.ts" />
-
+/// <reference path="../../mock/in-memory-cookies-service.ts"/>
 
 module labsFrontendApp
 {
@@ -11,11 +11,11 @@ module labsFrontendApp
         var cookie: ng.cookies.ICookiesService;
 
         beforeEach( module( 'labsFrontendApp' ) );
-        beforeEach( inject( ( $cookies: ng.cookies.ICookiesService ) =>
+        beforeEach( inject( () =>
         {
-            storage = new CookieJwtTokenStorage( $cookies );
-            $cookies.put( 'jwt', undefined );
-            cookie = $cookies;
+            cookie = new InMemoryCookiesService();
+            storage = new CookieJwtTokenStorage(cookie);
+            cookie.put( 'jwt', undefined );
         } ) );
 
         it( 'should store the token in a cookie', () =>

--- a/test/spec/services/jwt-token-storage.ts
+++ b/test/spec/services/jwt-token-storage.ts
@@ -8,7 +8,7 @@ module labsFrontendApp
     describe( 'CookieJwtTokenStorage', () =>
     {
         var storage: CookieJwtTokenStorage;
-        var cookie: ng.cookies.ICookiesService;
+        var cookie: InMemoryCookiesService;
 
         beforeEach( module( 'labsFrontendApp' ) );
         beforeEach( inject( () =>
@@ -22,6 +22,7 @@ module labsFrontendApp
         {
             storage.put( 'cats' );
             cookie.get('jwt').should.equal( 'cats' );
+            cookie.getOptions('jwt').secure.should.equal(true);
         } );
 
         it( 'should get the token from the cookie', () =>

--- a/test/spec/services/simple-http.ts
+++ b/test/spec/services/simple-http.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../../app/scripts/services/unauthorised-request-handler.ts" />
 /// <reference path="../../../app/scripts/services/jwt-token-storage.ts" />
 /// <reference path="../../../typings/tsd.d.ts" />
+/// <reference path="../../mock/services/jwt-token-storage.ts"/>
 
 module labsFrontendApp
 {
@@ -24,12 +25,12 @@ module labsFrontendApp
         var apiUrl: string;
 
         beforeEach( module( 'labsFrontendApp' ) );
-        beforeEach( inject( ( $cookies: ng.cookies.ICookiesService ) =>
+        beforeEach( inject( () =>
         {
             apiUrl = 'http://localhost/';
             var $injector = angular.injector([ 'ngMock' ]);
             $httpBackend = $injector.get( '$httpBackend' );
-            var jwtStorage = new CookieJwtTokenStorage( $cookies );
+            var jwtStorage = new InMemoryJwtTokenStorage();
             unauthorisedSpy = new UnauthorisedRequestHandlerSpy();
             service = new SimpleHttp( $injector.get('$http'), jwtStorage, unauthorisedSpy );
             jwtStorage.put( 'jwt!' );


### PR DESCRIPTION
Problems solved:
* In bower.json versions for angular packages were too loose, allowing to pull in even Angular 1.8. Starting from Angular 1.6 the default hash bang prefix changed from empty string to ```!``` (https://docs.angularjs.org/guide/migration#commit-aa077e8), which caused backward compatibility issues when the JWT authenticator external service returns with the JWT token. Namely it resulted in an infinite redirect loop due to missing hash bang prefix in the return URL. Since for now we don't want to make any major changes on this repo, we'll lock to Angular 1.4.
* The jwt cookie will now have the Secure flag enabled (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none).